### PR TITLE
Add clarification about `rg` in random_rotation()

### DIFF
--- a/keras_preprocessing/image/affine_transformations.py
+++ b/keras_preprocessing/image/affine_transformations.py
@@ -32,7 +32,8 @@ def random_rotation(x, rg, row_axis=1, col_axis=2, channel_axis=0,
 
     # Arguments
         x: Input tensor. Must be 3D.
-        rg: Rotation range, in degrees.
+        rg: Rotation range described as a single integer, in degrees. 
+            Will be applied as `(-rg,rg)`.
         row_axis: Index of axis for rows in the input tensor.
         col_axis: Index of axis for columns in the input tensor.
         channel_axis: Index of axis for channels in the input tensor.


### PR DESCRIPTION
the description for the argument `rg` was: "Rotation range, in degrees.". This commit adds a bit more detail so future users don't have to check the source code to be sure that they pass the intended value.

### Summary

### Related Issues

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
